### PR TITLE
Overwrite callback_url to ignore query string params

### DIFF
--- a/lib/omniauth/strategies/office365.rb
+++ b/lib/omniauth/strategies/office365.rb
@@ -34,6 +34,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get(authorize_params.resource + 'Me?api-version=1.5').parsed
       end
+      
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Based on this fix to another 365 gem:

https://github.com/murbanski/omniauth-microsoft-office365/pull/2/commits/706646625543ab4ea95d837d7f97d55fb3b61423